### PR TITLE
server: Define FUZZ_SERVER_PATH

### DIFF
--- a/fuzz_dynamorio/fuzzer.cpp
+++ b/fuzz_dynamorio/fuzzer.cpp
@@ -154,7 +154,7 @@ HANDLE getPipe() {
     HANDLE hPipe;
     while (1) {
         hPipe = CreateFile(
-            L"\\\\.\\pipe\\fuzz_server",
+            FUZZ_SERVER_PATH,
             GENERIC_READ | GENERIC_WRITE,
             0,
             NULL,
@@ -175,7 +175,7 @@ HANDLE getPipe() {
             dr_exit_process(1);
         }
 
-        if (!WaitNamedPipe(L"\\\\.\\pipe\\fuzz_server", 5000)) {
+        if (!WaitNamedPipe(FUZZ_SERVER_PATH, 5000)) {
             dr_log(NULL, LOG_ALL, ERROR, "Could not connect, timeout");
             dr_fprintf(STDERR, "Could not connect, timeout\n", err);
             dr_exit_process(1);

--- a/include/server.hpp
+++ b/include/server.hpp
@@ -1,6 +1,9 @@
 #ifndef SL2_SERVER_HPP
 #define SL2_SERVER_HPP
 
+// The path to the local named pipe, used by the server to communicate with clients.
+#define FUZZ_SERVER_PATH (L"\\\\.\\pipe\\fuzz_server")
+
 // The file (under the run directory) in which the name of the program is stored.
 #define FUZZ_RUN_PROGRAM_TXT (L"program.txt")
 

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -1061,7 +1061,7 @@ int main(int mArgc, char **mArgv)
 
     while (1) {
         HANDLE hPipe = CreateNamedPipe(
-            L"\\\\.\\pipe\\fuzz_server",
+            FUZZ_SERVER_PATH,
             PIPE_ACCESS_DUPLEX,
             PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_ACCEPT_REMOTE_CLIENTS,
             PIPE_UNLIMITED_INSTANCES,

--- a/triage_dynamorio/tracer.cpp
+++ b/triage_dynamorio/tracer.cpp
@@ -951,7 +951,7 @@ dump_crash(void *drcontext, dr_exception_t *excpt, std::string reason, uint8_t s
 
     if(replay) {
         HANDLE h_pipe = CreateFile(
-            L"\\\\.\\pipe\\fuzz_server",
+            FUZZ_SERVER_PATH,
             GENERIC_READ | GENERIC_WRITE,
             0,
             NULL,
@@ -1316,7 +1316,7 @@ wrap_post_GenericTaint(void *wrapcxt, void *user_data) {
         dr_mutex_lock(mutatex);
         // Open handle to server
         HANDLE h_pipe = CreateFile(
-            L"\\\\.\\pipe\\fuzz_server",
+            FUZZ_SERVER_PATH,
             GENERIC_READ | GENERIC_WRITE,
             0,
             NULL,


### PR DESCRIPTION
This allows us to remove the hardcoded paths in each of the server
clients, and gives us more flexibility for future refactoring.