### PR TITLE
make: Use cronbuild DR

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -22,20 +22,20 @@ Function InstallDependencies {
 Function DynamioRioInstall {
 
     $dynamorioDir = "dynamorio"
-    $dynamorioBase = "DynamoRIO-Windows-7.0.0-RC1"
+    $dynamorioBase = "DynamoRIO-Windows-7.0.17721-0"
 
     If ( Test-Path $dynamorioDir ) {
         $dynamorioDir + " already exists "
         return
-    } 
+    }
 
-    $url="https://github.com/DynamoRIO/dynamorio/releases/download/release_7_0_0_rc1/${dynamorioBase}.zip"
+    $url="https://github.com/DynamoRIO/dynamorio/releases/download/cronbuild-7.0.17721/${dynamorioBase}.zip"
     [Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'
     $client = New-Object System.Net.WebClient
 
     $zip = $cwd + "\dr.zip"
-    "Downloading " + $url 
+    "Downloading " + $url
     $client.DownloadFile($url, $zip)
     "Unzipping " + $zip
     Unzip $zip $cwd


### PR DESCRIPTION
The latest cronbuild includes official support for Windows
1803, which is what we're using.

This can wait until #59 is merged, since that's where I've done the work on updating the macros for logging.