### PR TITLE
tracer: fix type of mutate_count

### DIFF
--- a/triage_dynamorio/tracer.cpp
+++ b/triage_dynamorio/tracer.cpp
@@ -33,7 +33,7 @@ extern "C" {
 
 static void *mutatex;
 static bool replay;
-static bool mutate_count;
+static DWORD mutate_count;
 static UUID run_id;
 
 static std::set<reg_id_t> tainted_regs;


### PR DESCRIPTION
This should be a `DWORD`, not a `bool`.