### PR TITLE
api: allow clients to end session without closing conn

### DIFF
--- a/common/sl2_server_api.cpp
+++ b/common/sl2_server_api.cpp
@@ -65,13 +65,22 @@ __declspec(dllexport) SL2Response sl2_conn_open(sl2_conn *conn)
     return SL2Response::OK;
 }
 
-__declspec(dllexport) SL2Response sl2_conn_close(sl2_conn *conn)
+__declspec(dllexport) SL2Response sl2_conn_end_session(sl2_conn *conn)
 {
     uint8_t event = EVT_SESSION_TEARDOWN;
     DWORD txsize;
 
     // Tell the server that we want to end our session.
     SL2_CONN_WRITE(conn, &event, sizeof(event));
+
+    conn->has_run_id = false;
+
+    return SL2Response::OK;
+}
+
+__declspec(dllexport) SL2Response sl2_conn_close(sl2_conn *conn)
+{
+    sl2_conn_end_session(conn);
 
     CloseHandle(conn->pipe);
 

--- a/include/common/sl2_server_api.hpp
+++ b/include/common/sl2_server_api.hpp
@@ -65,6 +65,10 @@ struct sl2_crash_paths {
 // *or* `sl2_conn_assign_run_id`, depending on the client's needs.
 __declspec(dllexport) SL2Response sl2_conn_open(sl2_conn *conn);
 
+// Ends a session with the SL2 server, *without* closing the connection.
+// This allows an `sl2_conn` to be reused across multiple runs.
+__declspec(dllexport) SL2Response sl2_conn_end_session(sl2_conn *conn);
+
 // Closes an active connection with the SL2 server.
 // Clients *must not* exit before calling this.
 __declspec(dllexport) SL2Response sl2_conn_close(sl2_conn *conn);


### PR DESCRIPTION
This will help us re-use a client's connection to the server when restarting execution (instead of starting new instances of the fuzzer for each run).