### PR TITLE
fuzzer: add exception records to minidump

### DIFF
--- a/common/sl2_dr_client.cpp
+++ b/common/sl2_dr_client.cpp
@@ -1,9 +1,6 @@
 #include "common/sl2_dr_client.hpp"
-#include <string>
-#include <fstream>
 
 using namespace std;
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // SL2Client
@@ -133,5 +130,4 @@ __declspec(dllexport) void from_json(const json& j, targetFunction& t)
     t.functionName  = j.value("func_name", "");
     t.argHash       = j.value("argHash", "");
     t.buffer        = j["buffer"].get<vector<uint8_t>>();
-
 }

--- a/include/common/sl2_dr_client.hpp
+++ b/include/common/sl2_dr_client.hpp
@@ -1,15 +1,8 @@
 #ifndef SL2_DR_CLIENT_H
 #define SL2_DR_CLIENT_H
 
-// NOTE(ww): You might wonder why we don't include dr_api.h or other
-// DynamoRIO headers in this file. The short reason is that the DynamoRIO
-// headers rely on a bunch of macros that only get defined if you
-// declare your (CMake) target as a DynamoRIO client. Since slcommon
-// isn't a DynamoRIO client and defining all of those macros manually
-// would be fragile, we leave it up to the individual clients
-// to perform the includes.
-
 #include <string>
+#include <fstream>
 #include "vendor/json.hpp"
 using json = nlohmann::json;
 using namespace std;
@@ -108,7 +101,11 @@ struct client_read_info {
     size_t      nNumberOfBytesToRead;
 };
 
-
+struct sl2_exception_ctx {
+    DWORD thread_id;
+    EXCEPTION_RECORD record;
+    CONTEXT thread_ctx;
+};
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // SL2Client


### PR DESCRIPTION
This will make it easier to trace the actual crash path.

TODO:

- [x] Fix thread context (all registers appear to be zeroed out?)
- [x] Add to the triage minidump as well