### PR TITLE
server: use SL2_ARGV_LEN instead of hardcoding

### DIFF
--- a/include/common/util.h
+++ b/include/common/util.h
@@ -8,6 +8,12 @@
 // The size of a SHA256 hash.
 #define SL2_HASH_LEN 64
 
+// The maximum length of a target application's arguments (including program name and NULL).
+// NOTE(ww): This is based on the maximum argument length on the command line,
+// *not* the maximum length accepted by either CreateProcess or other WinAPI functions.
+// As such, it's mostly arbitrary.
+#define SL2_ARGV_LEN 8192
+
 // Convenience macros for testing normal and wide strings
 // for equality and case equality.
 #define STREQ(a, b) (!strcmp(a, b))

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -254,9 +254,7 @@ static void handleGenerateRunId(HANDLE pipe)
     LOG_F(INFO, "handleGenerateRunId: generated ID %S", run_id_s);
 
     // get program name
-    // TODO(ww): 8192 is the correct buffer size for the Windows command line, but
-    // we should try to find a macro in the WINAPI for it here.
-    wchar_t command_line[8192] = {0};
+    wchar_t command_line[SL2_ARGV_LEN] = {0};
     size_t size = 0;
     if (!ReadFile(pipe, &size, sizeof(size), &txsize, NULL)) {
         LOG_F(ERROR, "handleGenerateRunId: failed to read size of program name (0x%x)", GetLastError());
@@ -264,8 +262,8 @@ static void handleGenerateRunId(HANDLE pipe)
         exit(1);
     }
 
-    if (size > 8191) {
-        LOG_F(ERROR, "handleGenerateRunId: program name length %lu > 8191", size);
+    if ((size / sizeof(wchar_t)) > SL2_ARGV_LEN - 1) {
+        LOG_F(ERROR, "handleGenerateRunId: program name length %lu > SL2_ARGV_LEN - 1", size);
         exit(1);
     }
 
@@ -274,7 +272,7 @@ static void handleGenerateRunId(HANDLE pipe)
         exit(1);
     }
 
-    wchar_t target_file[MAX_PATH + 1] = { 0 };
+    wchar_t target_file[MAX_PATH + 1] = {0};
     PathCchCombine(target_file, MAX_PATH, run_dir, FUZZ_RUN_PROGRAM_TXT);
     HANDLE file = CreateFile(target_file, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, NULL);
 
@@ -293,7 +291,7 @@ static void handleGenerateRunId(HANDLE pipe)
         exit(1);
     }
 
-    memset(command_line, 0, 8192 * sizeof(wchar_t));
+    memset(command_line, 0, SL2_ARGV_LEN * sizeof(wchar_t));
 
     // get program arguments
     size = 0;
@@ -302,8 +300,8 @@ static void handleGenerateRunId(HANDLE pipe)
         exit(1);
     }
 
-    if (size > 8191) {
-        LOG_F(ERROR, "handleGenerateRunId: program argument list length > 8191");
+    if ((size / sizeof(wchar_t)) > SL2_ARGV_LEN - 1) {
+        LOG_F(ERROR, "handleGenerateRunId: program argument list length > SL2_ARGV_LEN - 1");
         exit(1);
     }
 


### PR DESCRIPTION
Fix overrun checks to account for widechars.