### PR TITLE
wizards: squash all truncation warnings

### DIFF
--- a/fuzz_dynamorio/fuzzer.cpp
+++ b/fuzz_dynamorio/fuzzer.cpp
@@ -75,7 +75,6 @@ static void get_target_command_line(wchar_t **argv, size_t *len)
     // alternatively: https://wj32.org/wp/2009/01/24/howto-get-the-command-line-of-processes/
     PEB * clientPEB = (PEB *) dr_get_app_PEB();
     RTL_USER_PROCESS_PARAMETERS parameterBlock;
-    size_t byte_counter;
 
     // Read process parameter block from PEB
     memcpy(&parameterBlock, clientPEB->ProcessParameters, sizeof(RTL_USER_PROCESS_PARAMETERS));
@@ -108,8 +107,7 @@ on_bb_instrument(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst, boo
         return DR_EMIT_DEFAULT;
     }
 
-    offset = start_pc - target_mod->start;
-    offset &= FUZZ_ARENA_SIZE - 1;
+    offset = (start_pc - target_mod->start) & (FUZZ_ARENA_SIZE - 1);
 
     drreg_reserve_aflags(drcontext, bb, inst);
     // TODO(ww): Is it really necessary to inject an instruction here?
@@ -283,12 +281,16 @@ mutate(Function function, HANDLE hFile, size_t position, void *buffer, size_t bu
 
 static void wrap_pre_IsProcessorFeaturePresent(void *wrapcxt, OUT void **user_data)
 {
+    #pragma warning(suppress: 4311 4302)
     DWORD feature = (DWORD) drwrap_get_arg(wrapcxt, 0);
+
+    #pragma warning(suppress: 4312)
     *user_data = (void *) feature;
 }
 
 static void wrap_post_IsProcessorFeaturePresent(void *wrapcxt, void *user_data)
 {
+    #pragma warning(suppress: 4311 4302)
     DWORD feature = (DWORD) user_data;
 
     if (feature == PF_FASTFAIL_AVAILABLE) {
@@ -350,9 +352,12 @@ wrap_pre_ReadEventLog(void *wrapcxt, OUT void **user_data)
 {
     SL2_DR_DEBUG("<in wrap_pre_ReadEventLog>\n");
     HANDLE hEventLog = (HANDLE)drwrap_get_arg(wrapcxt, 0);
+    #pragma warning(suppress: 4311 4302)
     DWORD  dwReadFlags = (DWORD)drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD  dwRecordOffset = (DWORD)drwrap_get_arg(wrapcxt, 2);
     void *lpBuffer = (void *)drwrap_get_arg(wrapcxt, 3);
+    #pragma warning(suppress: 4311 4302)
     DWORD  nNumberOfBytesToRead = (DWORD)drwrap_get_arg(wrapcxt, 4);
     DWORD  *pnBytesRead = (DWORD *)drwrap_get_arg(wrapcxt, 5);
     DWORD  *pnMinNumberOfBytesNeeded = (DWORD *)drwrap_get_arg(wrapcxt, 6);
@@ -430,8 +435,10 @@ wrap_pre_WinHttpWebSocketReceive(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_WinHttpWebSocketReceive>\n");
     HINTERNET hRequest = (HINTERNET)drwrap_get_arg(wrapcxt, 0);
     PVOID pvBuffer = drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD dwBufferLength = (DWORD)drwrap_get_arg(wrapcxt, 2);
     PDWORD pdwBytesRead = (PDWORD)drwrap_get_arg(wrapcxt, 3);
+    #pragma warning(suppress: 4311 4302)
     WINHTTP_WEB_SOCKET_BUFFER_TYPE peBufferType = (WINHTTP_WEB_SOCKET_BUFFER_TYPE)(int)drwrap_get_arg(wrapcxt, 3);
 
     // TODO: put this in another file cause you can't import wininet and winhttp
@@ -468,6 +475,7 @@ wrap_pre_InternetReadFile(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_InternetReadFile>\n");
     HINTERNET hFile = (HINTERNET)drwrap_get_arg(wrapcxt, 0);
     void *lpBuffer = drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD nNumberOfBytesToRead = (DWORD)drwrap_get_arg(wrapcxt, 2);
     LPDWORD lpNumberOfBytesRead = (LPDWORD)drwrap_get_arg(wrapcxt, 3);
 
@@ -504,8 +512,9 @@ wrap_pre_WinHttpReadData(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_WinHttpReadData>\n");
     HINTERNET hRequest = (HINTERNET)drwrap_get_arg(wrapcxt, 0);
     void *lpBuffer = drwrap_get_arg(wrapcxt, 1);
-    DWORD nNumberOfBytesToRead = (DWORD)drwrap_get_arg(wrapcxt, 2);
-    LPDWORD lpNumberOfBytesRead = (LPDWORD)drwrap_get_arg(wrapcxt, 3);
+    #pragma warning(suppress: 4311 4302)
+    DWORD nNumberOfBytesToRead = (DWORD) drwrap_get_arg(wrapcxt, 2);
+    DWORD *lpNumberOfBytesRead = (DWORD *) drwrap_get_arg(wrapcxt, 3);
 
     // LONG positionHigh = 0;
     // DWORD positionLow = InternetSetFilePointer(hRequest, 0, &positionHigh, FILE_CURRENT);
@@ -541,7 +550,9 @@ wrap_pre_recv(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_recv>\n");
     SOCKET s  = (SOCKET)drwrap_get_arg(wrapcxt, 0);
     char *buf = (char *)drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     int len   = (int)drwrap_get_arg(wrapcxt, 2);
+    #pragma warning(suppress: 4311 4302)
     int flags = (int)drwrap_get_arg(wrapcxt, 3);
 
     *user_data             = dr_thread_alloc(drwrap_get_drcontext(wrapcxt), sizeof(client_read_info));
@@ -574,6 +585,7 @@ wrap_pre_ReadFile(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_ReadFile>\n");
     HANDLE hFile                = drwrap_get_arg(wrapcxt, 0);
     void *lpBuffer             = drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD nNumberOfBytesToRead  = (DWORD)drwrap_get_arg(wrapcxt, 2);
     DWORD *lpNumberOfBytesRead = (DWORD*)drwrap_get_arg(wrapcxt, 3);
 
@@ -613,7 +625,9 @@ wrap_pre_fread_s(void *wrapcxt, OUT void **user_data)
 {
     SL2_DR_DEBUG("<in wrap_pre_fread_s>\n");
     void *buffer = (void *)drwrap_get_arg(wrapcxt, 0);
+    #pragma warning(suppress: 4311 4302)
     size_t size  = (size_t)drwrap_get_arg(wrapcxt, 2);
+    #pragma warning(suppress: 4311 4302)
     size_t count = (size_t)drwrap_get_arg(wrapcxt, 3);
     FILE *file   = (FILE *)drwrap_get_arg(wrapcxt, 4);
 
@@ -637,7 +651,9 @@ wrap_pre_fread(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_fread>\n");
 
     void *buffer = (void *)drwrap_get_arg(wrapcxt, 0);
+    #pragma warning(suppress: 4311 4302)
     size_t size  = (size_t)drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     size_t count = (size_t)drwrap_get_arg(wrapcxt, 2);
     FILE *file   = (FILE *)drwrap_get_arg(wrapcxt, 3);
 

--- a/triage_dynamorio/tracer.cpp
+++ b/triage_dynamorio/tracer.cpp
@@ -1099,12 +1099,16 @@ on_exception(void *drcontext, dr_exception_t *excpt)
 
 void wrap_pre_IsProcessorFeaturePresent(void *wrapcxt, OUT void **user_data)
 {
+    #pragma warning(suppress: 4311 4302)
     DWORD feature = (DWORD) drwrap_get_arg(wrapcxt, 0);
+
+    #pragma warning(suppress: 4312)
     *user_data = (void *) feature;
 }
 
 void wrap_post_IsProcessorFeaturePresent(void *wrapcxt, void *user_data)
 {
+    #pragma warning(suppress: 4311 4302)
     DWORD feature = (DWORD) user_data;
 
     if (feature == PF_FASTFAIL_AVAILABLE) {
@@ -1154,9 +1158,12 @@ wrap_pre_ReadEventLog(void *wrapcxt, OUT void **user_data)
 {
     SL2_DR_DEBUG("<in wrap_pre_ReadEventLog>\n");
     HANDLE hEventLog                 = (HANDLE)drwrap_get_arg(wrapcxt, 0);
+    #pragma warning(suppress: 4311 4302)
     DWORD  dwReadFlags               = (DWORD)drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD  dwRecordOffset            = (DWORD)drwrap_get_arg(wrapcxt, 2);
     void   *lpBuffer                 = (void *)drwrap_get_arg(wrapcxt, 3);
+    #pragma warning(suppress: 4311 4302)
     DWORD  nNumberOfBytesToRead      = (DWORD)drwrap_get_arg(wrapcxt, 4);
     DWORD  *pnBytesRead              = (DWORD *)drwrap_get_arg(wrapcxt, 5);
     DWORD  *pnMinNumberOfBytesNeeded = (DWORD *)drwrap_get_arg(wrapcxt, 6);
@@ -1203,8 +1210,10 @@ wrap_pre_WinHttpWebSocketReceive(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_WinHttpWebSocketReceive>\n");
     HINTERNET hRequest                          = (HINTERNET)drwrap_get_arg(wrapcxt, 0);
     void *pvBuffer                              = drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD dwBufferLength                        = (DWORD)drwrap_get_arg(wrapcxt, 2);
     DWORD *pdwBytesRead                         = (DWORD *)drwrap_get_arg(wrapcxt, 3);
+    #pragma warning(suppress: 4311 4302)
     WINHTTP_WEB_SOCKET_BUFFER_TYPE peBufferType = (WINHTTP_WEB_SOCKET_BUFFER_TYPE)(int)drwrap_get_arg(wrapcxt, 3);
 
     *user_data             = dr_thread_alloc(drwrap_get_drcontext(wrapcxt), sizeof(client_read_info));
@@ -1223,6 +1232,7 @@ wrap_pre_InternetReadFile(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_InternetReadFile>\n");
     HINTERNET hFile             = (HINTERNET)drwrap_get_arg(wrapcxt, 0);
     void *lpBuffer              = drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD nNumberOfBytesToRead  = (DWORD)drwrap_get_arg(wrapcxt, 2);
     DWORD *lpNumberOfBytesRead  = (DWORD*)drwrap_get_arg(wrapcxt, 3);
 
@@ -1242,6 +1252,7 @@ wrap_pre_WinHttpReadData(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_WinHttpReadData>\n");
     HINTERNET hRequest          = (HINTERNET)drwrap_get_arg(wrapcxt, 0);
     void *lpBuffer              = drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD nNumberOfBytesToRead  = (DWORD)drwrap_get_arg(wrapcxt, 2);
     DWORD *lpNumberOfBytesRead  = (DWORD*)drwrap_get_arg(wrapcxt, 3);
 
@@ -1261,7 +1272,9 @@ wrap_pre_recv(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_recv>\n");
     SOCKET s  = (SOCKET)drwrap_get_arg(wrapcxt, 0);
     char *buf = (char *)drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     int len   = (int)drwrap_get_arg(wrapcxt, 2);
+    #pragma warning(suppress: 4311 4302)
     int flags = (int)drwrap_get_arg(wrapcxt, 3);
 
     *user_data             = dr_thread_alloc(drwrap_get_drcontext(wrapcxt), sizeof(client_read_info));
@@ -1280,6 +1293,7 @@ wrap_pre_ReadFile(void *wrapcxt, OUT void **user_data)
     SL2_DR_DEBUG("<in wrap_pre_ReadFile>\n");
     HANDLE hFile                = drwrap_get_arg(wrapcxt, 0);
     void *lpBuffer              = drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD nNumberOfBytesToRead  = (DWORD)drwrap_get_arg(wrapcxt, 2);
     DWORD *lpNumberOfBytesRead  = (DWORD*)drwrap_get_arg(wrapcxt, 3);
 
@@ -1316,7 +1330,9 @@ wrap_pre_fread_s(void *wrapcxt, OUT void **user_data)
 {
     SL2_DR_DEBUG("<in wrap_pre_fread_s>\n");
     void *buffer = (void *)drwrap_get_arg(wrapcxt, 0);
+    #pragma warning(suppress: 4311 4302)
     size_t size  = (size_t)drwrap_get_arg(wrapcxt, 2);
+    #pragma warning(suppress: 4311 4302)
     size_t count = (size_t)drwrap_get_arg(wrapcxt, 3);
 
     *user_data             = dr_thread_alloc(drwrap_get_drcontext(wrapcxt), sizeof(client_read_info));
@@ -1334,7 +1350,9 @@ wrap_pre_fread(void *wrapcxt, OUT void **user_data)
 {
     SL2_DR_DEBUG("<in wrap_pre_fread>\n");
     void *buffer = (void *)drwrap_get_arg(wrapcxt, 0);
+    #pragma warning(suppress: 4311 4302)
     size_t size  = (size_t)drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     size_t count = (size_t)drwrap_get_arg(wrapcxt, 2);
 
     *user_data             = dr_thread_alloc(drwrap_get_drcontext(wrapcxt), sizeof(client_read_info));

--- a/wizard/wizard.cpp
+++ b/wizard/wizard.cpp
@@ -81,13 +81,16 @@ wrap_pre_ReadEventLog(void *wrapcxt, OUT void **user_data)
     *user_data             = dr_thread_alloc(drwrap_get_drcontext(wrapcxt), sizeof(wizard_read_info));
     wizard_read_info *info = (wizard_read_info *) *user_data;
 
-    HANDLE hEventLog                 = (HANDLE)drwrap_get_arg(wrapcxt, 0);
-    DWORD  dwReadFlags               = (DWORD)drwrap_get_arg(wrapcxt, 1);
-    DWORD  dwRecordOffset            = (DWORD)drwrap_get_arg(wrapcxt, 2);
-    void *lpBuffer                   = (void *)drwrap_get_arg(wrapcxt, 3);
-    size_t  nNumberOfBytesToRead     = (size_t)drwrap_get_arg(wrapcxt, 4);
-    DWORD  *pnBytesRead              = (DWORD *)drwrap_get_arg(wrapcxt, 5);
-    DWORD  *pnMinNumberOfBytesNeeded = (DWORD *)drwrap_get_arg(wrapcxt, 6);
+    HANDLE hEventLog                 = (HANDLE) drwrap_get_arg(wrapcxt, 0);
+    #pragma warning(suppress: 4311 4302)
+    DWORD  dwReadFlags               = (DWORD) drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
+    DWORD  dwRecordOffset            = (DWORD) drwrap_get_arg(wrapcxt, 2);
+    void *lpBuffer                   = drwrap_get_arg(wrapcxt, 3);
+    #pragma warning(suppress: 4311 4302)
+    size_t  nNumberOfBytesToRead     = (DWORD) drwrap_get_arg(wrapcxt, 4);
+    DWORD  *pnBytesRead              = (DWORD *) drwrap_get_arg(wrapcxt, 5);
+    DWORD  *pnMinNumberOfBytesNeeded = (DWORD *) drwrap_get_arg(wrapcxt, 6);
 
     info->lpBuffer             = lpBuffer;
     info->nNumberOfBytesToRead = nNumberOfBytesToRead;
@@ -102,12 +105,12 @@ wrap_pre_ReadEventLog(void *wrapcxt, OUT void **user_data)
 static void
 wrap_pre_RegQueryValueEx(void *wrapcxt, OUT void **user_data)
 {
-    HKEY hKey         = (HKEY)drwrap_get_arg(wrapcxt, 0);
-    char *lpValueName = (char *)drwrap_get_arg(wrapcxt, 1);
-    DWORD *lpReserved = (DWORD *)drwrap_get_arg(wrapcxt, 2);
-    DWORD *lpType     = (DWORD *)drwrap_get_arg(wrapcxt, 3);
-    BYTE *lpData      = (BYTE *)drwrap_get_arg(wrapcxt, 4);
-    DWORD *lpcbData   = (DWORD *)drwrap_get_arg(wrapcxt, 5);
+    HKEY hKey         = (HKEY) drwrap_get_arg(wrapcxt, 0);
+    char *lpValueName = (char *) drwrap_get_arg(wrapcxt, 1);
+    DWORD *lpReserved = (DWORD *) drwrap_get_arg(wrapcxt, 2);
+    DWORD *lpType     = (DWORD *) drwrap_get_arg(wrapcxt, 3);
+    BYTE *lpData      = (BYTE *) drwrap_get_arg(wrapcxt, 4);
+    DWORD *lpcbData   = (DWORD *) drwrap_get_arg(wrapcxt, 5);
 
     // get registry key path (maybe hook open key?)
 
@@ -134,11 +137,13 @@ wrap_pre_WinHttpWebSocketReceive(void *wrapcxt, OUT void **user_data)
     *user_data             = dr_thread_alloc(drwrap_get_drcontext(wrapcxt), sizeof(wizard_read_info));
     wizard_read_info *info = (wizard_read_info *) *user_data;
 
-    HINTERNET hRequest                          = (HINTERNET)drwrap_get_arg(wrapcxt, 0);
+    HINTERNET hRequest                          = (HINTERNET) drwrap_get_arg(wrapcxt, 0);
     void *pvBuffer                              = drwrap_get_arg(wrapcxt, 1);
-    DWORD dwBufferLength                        = (DWORD)drwrap_get_arg(wrapcxt, 2);
-    DWORD *pdwBytesRead                         = (DWORD *)drwrap_get_arg(wrapcxt, 3);
-    WINHTTP_WEB_SOCKET_BUFFER_TYPE peBufferType = (WINHTTP_WEB_SOCKET_BUFFER_TYPE)(int)drwrap_get_arg(wrapcxt, 3);
+    #pragma warning(suppress: 4311 4302)
+    DWORD dwBufferLength                        = (DWORD) drwrap_get_arg(wrapcxt, 2);
+    DWORD *pdwBytesRead                         = (DWORD *) drwrap_get_arg(wrapcxt, 3);
+    #pragma warning(suppress: 4311 4302)
+    WINHTTP_WEB_SOCKET_BUFFER_TYPE peBufferType = (WINHTTP_WEB_SOCKET_BUFFER_TYPE) (int) drwrap_get_arg(wrapcxt, 3);
 
     // get url
     // InternetQueryOption
@@ -158,10 +163,11 @@ wrap_pre_InternetReadFile(void *wrapcxt, OUT void **user_data)
     *user_data             = dr_thread_alloc(drwrap_get_drcontext(wrapcxt), sizeof(wizard_read_info));
     wizard_read_info *info = (wizard_read_info *) *user_data;
 
-    HINTERNET hFile             = (HINTERNET)drwrap_get_arg(wrapcxt, 0);
+    HINTERNET hFile            = (HINTERNET) drwrap_get_arg(wrapcxt, 0);
     void *lpBuffer             = drwrap_get_arg(wrapcxt, 1);
-    DWORD nNumberOfBytesToRead  = (DWORD)drwrap_get_arg(wrapcxt, 2);
-    DWORD *lpNumberOfBytesRead = (DWORD *)drwrap_get_arg(wrapcxt, 3);
+    #pragma warning(suppress: 4311 4302)
+    DWORD nNumberOfBytesToRead = (DWORD) drwrap_get_arg(wrapcxt, 2);
+    DWORD *lpNumberOfBytesRead = (DWORD *) drwrap_get_arg(wrapcxt, 3);
 
     // get url
     // InternetQueryOption
@@ -183,6 +189,7 @@ wrap_pre_WinHttpReadData(void *wrapcxt, OUT void **user_data)
 
     HINTERNET hRequest         = (HINTERNET)drwrap_get_arg(wrapcxt, 0);
     void *lpBuffer             = drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD nNumberOfBytesToRead = (DWORD)drwrap_get_arg(wrapcxt, 2);
     DWORD *lpNumberOfBytesRead = (DWORD*)drwrap_get_arg(wrapcxt, 3);
 
@@ -206,7 +213,9 @@ wrap_pre_recv(void *wrapcxt, OUT void **user_data)
 
     SOCKET s  = (SOCKET)drwrap_get_arg(wrapcxt, 0);
     char *buf = (char *)drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     int len   = (int)drwrap_get_arg(wrapcxt, 2);
+    #pragma warning(suppress: 4311 4302)
     int flags = (int)drwrap_get_arg(wrapcxt, 3);
 
     // get ip address
@@ -235,6 +244,7 @@ wrap_pre_ReadFile(void *wrapcxt, OUT void **user_data)
 {
     HANDLE hFile               = drwrap_get_arg(wrapcxt, 0);
     void *lpBuffer             = drwrap_get_arg(wrapcxt, 1);
+    #pragma warning(suppress: 4311 4302)
     DWORD nNumberOfBytesToRead = (DWORD)drwrap_get_arg(wrapcxt, 2);
     DWORD *lpNumberOfBytesRead = (DWORD *)drwrap_get_arg(wrapcxt, 3);
 


### PR DESCRIPTION
This just adds `#pragma warning(suppress: XXX)` to lines where we know that we're performing pointer (or other width) truncations safely.

Closes #67.