### PR TITLE
harness: add support for saving PRNG seeds

### DIFF
--- a/harness/instrument.py
+++ b/harness/instrument.py
@@ -80,7 +80,8 @@ def run_dr(config_dict, verbose=False, timeout=None):
     """
     Runs dynamorio with the given config.
     Clobbers console output if save_stderr/stdout are true.
-    Returns a popen object and the PRNG seed used during the run.
+    Returns a DRRun instance containing the popen object and PRNG seed
+    used during the run.
     """
     invoke = create_invocation_statement(config_dict)
 

--- a/harness/state.py
+++ b/harness/state.py
@@ -46,9 +46,8 @@ def unique_pidfile():
 
 def create_invocation_statement(config_dict):
     """
-    Returns a tuple of a DR invocation (as an array),
-    its stringified equivalent, and the pidfile that
-    will be created by the invocation.
+    Returns an InvocationState containing the command run,
+    its incipient pidfile, and the PRNG seed used.
     """
     pidfile = unique_pidfile()
     seed = str(random.getrandbits(64))


### PR DESCRIPTION
fuzz.seed and triage.seed are now saved under each run directory.

See #70.