### PR TITLE
Fix some program string serializing issues

### DIFF
--- a/harness/config.py
+++ b/harness/config.py
@@ -171,23 +171,6 @@ parser.add_argument(
     By default, runs are not killed.")
 
 parser.add_argument(
-    '--seed',
-    action='store',
-    dest='seed',
-    type=int,
-    help="PRNG Seed to use for mutations. Leaving this blank will \
-    result in a randomly chosen seed. You should use a random seed \
-    unless trying to replay a specific run.")
-
-parser.add_argument(
-    '--run_id',
-    action='store',
-    dest='run_id',
-    type=str,
-    help="Set the Run ID for a given run to a specific value instead \
-    of using an auto-generated value. Useful for replaying triage runs.")
-
-parser.add_argument(
     '-r', '--runs',
     action='store',
     dest='runs',
@@ -239,6 +222,14 @@ parser.add_argument(
     dest='preserve_runs',
     default=False,
     help="Preserve all fuzzer runs, even when they don't cause crashes")
+
+parser.add_argument(
+    '--run_id',
+    action='store',
+    dest='run_id',
+    type=str,
+    help="Set the Run ID for a given run to a specific value instead \
+    of using an auto-generated value. Useful for replaying triage runs.")
 
 args = parser.parse_args()
 

--- a/harness/instrument.py
+++ b/harness/instrument.py
@@ -83,7 +83,7 @@ def run_dr(config_dict, verbose=False, timeout=None, run_id=None, tracing=False)
     Returns a DRRun instance containing the popen object and PRNG seed
     used during the run.
     """
-    invoke = create_invocation_statement(config_dict)
+    invoke = create_invocation_statement(config_dict, run_id)
 
     if verbose:
         print_l("Executing drrun: %s" % invoke.cmd_str)
@@ -292,7 +292,8 @@ def triage_run(config_dict, run_id):
             'inline_stdout': config_dict['inline_stdout']
         },
         config_dict['verbose'],
-        config_dict.get('triage_timeout', None)
+        config_dict.get('triage_timeout', None),
+        run_id=run_id
     )
 
     # Write stdout and stderr to files


### PR DESCRIPTION
Properly (I hope) quotes program strings before writing them to the argument file and properly displays the run id argument in the message for re-running the tracer. This should make replicating buggy runs easier. Also generates seeds from the random bits of run ID's so that the PRNG behavior will be exactly the same between fuzzing and triage runs. 