### PR TITLE
Fixed #269- File format versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,3 +287,8 @@ You can safely ignore most of the stuff in `corpus/asm` and `electriage`
 
 ## 20180808
 Changed passing of arguments to clients and target applications from using comma separated to just normally how it would appear on the command line. The `shlex.split()` function will split them up appropriately
+
+
+# Developer Information
+
+If you change anything that would break backwards compatility, increment  `harness.config.VERSION`.  This includes any database changes, formats, directory structures, filenames etc..

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -10,8 +10,46 @@ import os
 import db.base
 
 
+
+def getSession():
+    """
+    Used to get a session for db stuff.  You can't reuse a session or db objects across
+    threads
+    """
+    return Session()
+
+
+
+def checkVersionNumber():
+    versionNow = config.VERSION
+    confVersion = db.Conf.factory('version')
+    if not confVersion:
+        print("There is no existing version. adding")
+        db.Conf.factory( "version", versionNow )
+        return
+
+    if confVersion.value < versionNow:
+        msg = """Current configuration version %d is older than software version of %d .
+This means your configuration and data in the SL2 directory are older than the current code.
+Options include:
+  * Run  ./make reconfig
+  * Remove the SL2 directory in %s
+        """ % (confVersion.value, versionNow, config.sl2_dir)
+        print("!"*77)
+        print(msg)
+        print("!"*77)
+        xception = BaseException(msg)
+        raise( xception )
+
+    else:
+        print("Versions match!", versionNow )
+
+
+
+
 dburl = os.path.join( 'sqlite:///%s/%s'% ( config.sl2_dir, 'sl2.db' ) )
 engine = create_engine(dburl, poolclass=NullPool )
+from .conf import Conf
 from .tracer import Tracer
 from .checksec import Checksec
 from .crash import Crash
@@ -24,9 +62,5 @@ Session = scoped_session(Session)
 Session().commit()
 
 
-def getSession():
-    """
-    Used to get a session for db stuff.  You can't reuse a session or db objects across
-    threads
-    """
-    return Session()
+checkVersionNumber()
+

--- a/harness/config.py
+++ b/harness/config.py
@@ -22,6 +22,10 @@ import shlex
 # TODO(ww): Add conversion to the schema as well?
 CONFIG_SCHEMA = {}
 
+# Increment this version number for any changes that might break backwards compatibilty.
+# This could be database schema changes, paths, file glob patterns, etc..
+VERSION=2
+
 PATH_KEYS = ['drrun_path', 'client_path', 'server_path', 'wizard_path', 'tracer_path', 'triager_path']
 ARGS_KEYS = ['drrun_args', 'client_args', 'server_args', 'target_args']
 INT_KEYS = ['runs', 'simultaneous', 'fuzz_timeout', 'tracer_timeout', 'seed', 'verbose']


### PR DESCRIPTION
If you change anything that would break backwards compatility, increment  `harness.config.VERSION`.  This includes any database changes, formats, directory structures, filenames etc..