### PR TITLE
common, fuzzer, tracer: Dedupe mitigations

### DIFF
--- a/common/sl2_dr_client.cpp
+++ b/common/sl2_dr_client.cpp
@@ -208,7 +208,7 @@ SL2Client::wrap_post_IsProcessorFeaturePresent(void *wrapcxt, void *user_data)
 }
 
 void
-SL2Client::wrap_pre_UnhandledExceptionFilter(void *wrapcxt, OUT void **user_data)
+SL2Client::wrap_pre_UnhandledExceptionFilter(void *wrapcxt, OUT void **user_data, bool (*on_exception)(void *, dr_exception_t *))
 {
     SL2_DR_DEBUG("wrap_pre_UnhandledExceptionFilter: stealing unhandled exception\n");
 
@@ -226,7 +226,7 @@ SL2Client::wrap_pre_UnhandledExceptionFilter(void *wrapcxt, OUT void **user_data
 */
 
 void
-SL2Client::wrap_pre_VerifierStopMessage(void *wrapcxt, OUT void **user_data)
+SL2Client::wrap_pre_VerifierStopMessage(void *wrapcxt, OUT void **user_data, bool (*on_exception)(void *, dr_exception_t *))
 {
     SL2_DR_DEBUG("wrap_pre_VerifierStopMessage: stealing unhandled exception\n");
 

--- a/fuzz_dynamorio/fuzzer.cpp
+++ b/fuzz_dynamorio/fuzzer.cpp
@@ -230,12 +230,12 @@ static void wrap_post_IsProcessorFeaturePresent(void *wrapcxt, void *user_data)
 
 static void wrap_pre_UnhandledExceptionFilter(void *wrapcxt, OUT void **user_data)
 {
-    client.wrap_pre_UnhandledExceptionFilter(wrapcxt, user_data);
+    client.wrap_pre_UnhandledExceptionFilter(wrapcxt, user_data, on_exception);
 }
 
 static void wrap_pre_VerifierStopMessage(void *wrapcxt, OUT void **user_data)
 {
-    client.wrap_pre_VerifierStopMessage(wrapcxt, user_data);
+    client.wrap_pre_VerifierStopMessage(wrapcxt, user_data, on_exception);
 }
 
 static void

--- a/include/common/sl2_dr_client.hpp
+++ b/include/common/sl2_dr_client.hpp
@@ -195,9 +195,9 @@ public:
 
     // Crash-diversion mitigation methods.
     void        wrap_pre_IsProcessorFeaturePresent(void *wrapcxt, OUT void **user_data);
-    void        wrap_post_IsProcessorFeaturePresent(void *wrapcxt, OUT void **user_data);
-    void        wrap_pre_UnhandledExceptionFilter(void *wrapcxt, OUT void **user_data);
-    void        wrap_pre_VerifierStopMessage(void *wrapcxt, OUT void **user_data);
+    void        wrap_post_IsProcessorFeaturePresent(void *wrapcxt, OUT void *user_data);
+    void        wrap_pre_UnhandledExceptionFilter(void *wrapcxt, OUT void **user_data, bool (*on_exception)(void *, dr_exception_t *));
+    void        wrap_pre_VerifierStopMessage(void *wrapcxt, OUT void **user_data, bool (*on_exception)(void *, dr_exception_t *));
 
     // Pre- and post-hook related methods.
     void        wrap_pre_ReadEventLog(void *wrapcxt, OUT void **user_data);

--- a/tracer_dynamorio/tracer.cpp
+++ b/tracer_dynamorio/tracer.cpp
@@ -1098,12 +1098,12 @@ static void wrap_post_IsProcessorFeaturePresent(void *wrapcxt, void *user_data)
 
 static void wrap_pre_UnhandledExceptionFilter(void *wrapcxt, OUT void **user_data)
 {
-    client.wrap_pre_UnhandledExceptionFilter(wrapcxt, user_data);
+    client.wrap_pre_UnhandledExceptionFilter(wrapcxt, user_data, on_exception);
 }
 
 static void wrap_pre_VerifierStopMessage(void *wrapcxt, OUT void **user_data)
 {
-    client.wrap_pre_VerifierStopMessage(wrapcxt, user_data);
+    client.wrap_pre_VerifierStopMessage(wrapcxt, user_data, on_exception);
 }
 
 /*


### PR DESCRIPTION
This moves our crash-diversion mitigations into `SL2Client` a la our pre- and post-hooks for fuzzable functions.