### PR TITLE
Add Checks for Python/OS Version

### DIFF
--- a/sl2/harness/config.py
+++ b/sl2/harness/config.py
@@ -26,6 +26,9 @@ CONFIG_SCHEMA = {}
 # This could be database schema changes, paths, file glob patterns, etc..
 VERSION = 12
 
+# Recommended Windows Release. Increment this as new DynamoRIO builds come out.
+RECOMMENDED_WIN10_VERSION = 1803
+
 PATH_KEYS = ['drrun_path', 'client_path', 'server_path', 'wizard_path', 'tracer_path', 'triager_path']
 ARGS_KEYS = ['drrun_args', 'client_args', 'server_args', 'target_args']
 INT_KEYS = ['runs', 'simultaneous', 'fuzz_timeout', 'tracer_timeout', 'seed', 'verbose', 'function_number']


### PR DESCRIPTION
As of right now, the recommended Windows 10 version is stored in the config file, so we won't be able to just tell the user to download the new DynamoRIO release when it's available. We'll have to provide them with a whole new bundle. 